### PR TITLE
Add recently viewed content feature

### DIFF
--- a/lib/Feature/home/presentation/widgets/recntly_viewed_list_view.dart
+++ b/lib/Feature/home/presentation/widgets/recntly_viewed_list_view.dart
@@ -24,7 +24,7 @@ class RecntlyViewedListView extends StatelessWidget {
       builder: (context, state) {
         ExplorCubit cubit = ExplorCubit.getObject(context);
         final List<PlantModle> shuffledPlants = List.of(cubit.plantsresult)
-          ..shuffle(); // show the list Random
+          ..shuffle(); 
         if (state is GetPlantDataSuccessState) {
           return FadeInUp(
             child: Column(

--- a/lib/Feature/profile/presentation/widgets/general_profile_components.dart
+++ b/lib/Feature/profile/presentation/widgets/general_profile_components.dart
@@ -36,7 +36,13 @@ class GeneralProfileComponents extends StatelessWidget {
             width: 30.w,
             height: 30.h,
           ),
-          trailing: const Icon(Icons.arrow_right),
+          trailing: GestureDetector(
+              onTap: () => {
+                    context.navigateTo(
+                      routeName: Routes.recentlyViewedContent,
+                    )
+                  },
+              child: const Icon(Icons.arrow_right)),
         ),
         verticalSpacing(8),
         const Divider(

--- a/lib/Feature/profile/presentation/widgets/recntly_viewed_content.dart
+++ b/lib/Feature/profile/presentation/widgets/recntly_viewed_content.dart
@@ -1,0 +1,79 @@
+import 'dart:math';
+import 'package:animate_do/animate_do.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:smartsoil/Feature/explor/data/models/explor_plant_models.dart';
+import 'package:smartsoil/Feature/explor/logic/cubit/explor_cubit.dart';
+import 'package:smartsoil/core/widgets/popular_card.dart';
+import 'package:smartsoil/core/helper/spacing.dart';
+import 'package:smartsoil/core/themaing/app_colors.dart';
+import 'package:smartsoil/core/widgets/custom_error_widget.dart';
+
+class RecntlyViewedContent extends StatelessWidget {
+  const RecntlyViewedContent({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<ExplorCubit, ExplorState>(
+      builder: (context, state) {
+        ExplorCubit cubit = ExplorCubit.getObject(context);
+        final List<PlantModle> shuffledPlants = List.of(cubit.plantsresult)
+          ..shuffle();
+        if (state is GetPlantDataSuccessState) {
+          return Scaffold(
+            appBar: AppBar(
+              title: const Text('Recently viewed'),
+            ),
+            body: FadeInUp(
+              child: Padding(
+                padding: EdgeInsets.only(
+                  bottom: 16.h,
+                  right: 27.w,
+                  left: 14.w,
+                ),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    verticalSpacing(24),
+                    Expanded(
+                      child: ListView.builder(
+                        shrinkWrap: true,
+                        physics: const BouncingScrollPhysics(),
+                        clipBehavior: Clip.none,
+                        itemCount: min(
+                          15,
+                          shuffledPlants.length,
+                        ),
+                        scrollDirection: Axis.vertical,
+                        itemBuilder: (context, index) {
+                          return Padding(
+                            padding: EdgeInsets.only(right: 16.w, top: 28.h),
+                            child: PopularCard(
+                              plant: shuffledPlants[index],
+                            ),
+                          );
+                        },
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          );
+        } else if (state is GetPlantDataErrorState) {
+          return CustomErrorWidget(
+            error: state.errormassage,
+            onPressed: () => cubit.getPlants(),
+          );
+        } else {
+          return const Center(
+            child: CircularProgressIndicator(
+              color: ColorManger.primaryColor,
+            ),
+          );
+        }
+      },
+    );
+  }
+}

--- a/lib/core/routing/app_routes.dart
+++ b/lib/core/routing/app_routes.dart
@@ -17,6 +17,7 @@ import 'package:smartsoil/Feature/layout/presentation/views/layout_views.dart';
 import 'package:smartsoil/Feature/onbording/logic/cubit/onbording_cubit.dart';
 import 'package:smartsoil/Feature/onbording/presentation/on_boarding_view.dart';
 import 'package:smartsoil/Feature/profile/presentation/widgets/favorite_content.dart';
+import 'package:smartsoil/Feature/profile/presentation/widgets/recntly_viewed_content.dart';
 import 'package:smartsoil/Feature/recommendNextCrop/logic/recommend_next_crop_cubit.dart';
 import 'package:smartsoil/Feature/recommendNextCrop/presentation/views/recommed_next_plant.dart';
 import 'package:smartsoil/Feature/search/presentation/views/search_store_view.dart';
@@ -93,6 +94,10 @@ class AppRoutes {
       case Routes.searchStoreViewRoute:
         return MaterialPageRoute(
           builder: (context) => const SearchStoreView(),
+        );
+      case Routes.recentlyViewedContent:
+        return MaterialPageRoute(
+          builder: (context) => const RecntlyViewedContent(),
         );
 
       case Routes.recentlySeeAllViewViewRoute:

--- a/lib/core/routing/routes.dart
+++ b/lib/core/routing/routes.dart
@@ -19,4 +19,6 @@ class Routes {
       '/recommedNextCropsViewRoute';
   static const String chatViewRoute = '/chatView';
   static const String favoriteContentViewRoute = '/favoriteContentView';
+
+  static const String recentlyViewedContent = '/RecentlyViewedContent';
 }


### PR DESCRIPTION
- Added a new widget for displaying recently viewed content in the profile section.
- Updated routing to navigate to the recently viewed content screen.
- Implemented logic to fetch and display recently viewed plants.
- Included animations and UI enhancements for the recently viewed content screen.